### PR TITLE
Add method for requesting current time entry

### DIFF
--- a/lib/toggl_api/api/time_entry.rb
+++ b/lib/toggl_api/api/time_entry.rb
@@ -55,6 +55,12 @@ module Toggl
 
       alias :time_entries :get_time_entries
 
+      def get_current_time_entry
+        get "time_entries/current"
+      end
+
+      alias :current_time_entry :get_current_time_entry
+
       def update_time_entry(tid,options)
         tid = tid.join(",") if tid.is_a? Array
         options = Hashie::Mash.new options

--- a/test/test_time_entry.rb
+++ b/test/test_time_entry.rb
@@ -20,6 +20,13 @@ class TimeEntryTest < MiniTest::Unit::TestCase
     end 
   end
 
+  def test_get_current_time_entry
+    @base.stub :request, Faraday::Response.new(:body => load_fixture('time_entry')) do
+      resp = @base.current_time_entry
+      refute_nil resp.body
+    end
+  end
+
   def test_update_time_entry
     @base.stub :request, Faraday::Response.new(:body => load_fixture('update_time_entry')) do
       resp = @base.update_time_entry(123,{"name" => "test"})


### PR DESCRIPTION
I noticed that the library has this api call missing (https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md#get-running-time-entry) since I needed it in a toggl client I'm developing.
