### PR TITLE
Fix bug of start_time_entry

### DIFF
--- a/lib/toggl_api/api/time_entry.rb
+++ b/lib/toggl_api/api/time_entry.rb
@@ -22,6 +22,7 @@ module Toggl
 
       def start_time_entry(options)
         options = Hashie::Mash.new options
+        options = options.merge({:created_with => "Toggl Api Ruby Gem #{Toggl::VERSION}"})
         post "/time_entries/start", (options.key?(:time_entry) ? options : {:time_entry => options})
       end
 


### PR DESCRIPTION
When I used start_time_entry method,  I got the following output.
`Toggl::BadRequest: (400): created_with needs to be provided an a valid string`

So, I check toggl_api_docs.
https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md

I found the following description.
`created_with: the name of your client app (string, required)`
To see this, created_with is required property.
But, start_time_entry method don't add this property.
So, add this property.
